### PR TITLE
Make the HTTP client actually set the headers

### DIFF
--- a/lib/ClientBase.js
+++ b/lib/ClientBase.js
@@ -126,6 +126,9 @@ ClientBase.prototype._generateReqOptions = function(url, path, body, method, hea
     }
   };
 
+  options.headers = assign(options.headers, headers);
+    
+    
   // add additional headers when we're using the "api key" and "api secret"
   if (this.apiSecret && this.apiKey) {
     var sig = this._generateSignature(path, method, bodyStr);


### PR DESCRIPTION
Otherwise 2FA and other stuff relying on headers is just non-working. 